### PR TITLE
Fixed ensure changed 'stopped' to 'running each puppet run, while the…

### DIFF
--- a/manifests/client/service.pp
+++ b/manifests/client/service.pp
@@ -8,7 +8,6 @@ class xymon::client::service {
   service { 'xymon-client':
     ensure     => running,
     enable     => true,
-    hasstatus  => false,
     hasrestart => true,
   }
 }


### PR DESCRIPTION
… service is already running.

The service init script does have a status command (at least in Debian). The default since puppet 2.7 is to true for the hasstatus property.  With false puppet tries to verify the service is running based on the name of the service in the in the process table. The pattern is not set and /usr/lib/xymon/client/bin/xymonlaunch (used by debian) does not match xymon-client which is used to verify the service is running.